### PR TITLE
refactor hash entry type for initialization

### DIFF
--- a/ternary_tree.nimble
+++ b/ternary_tree.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.29"
+version       = "0.1.30"
 author        = "jiyinyiyong"
 description   = "Ternary tree of list data structure"
 license       = "MIT"


### PR DESCRIPTION
There was potential problem during map initialization when hash collapsing happens. Refactored to hash entry type to bypass the risk.